### PR TITLE
Get an instance with all ComputeOrderInstance attributes

### DIFF
--- a/src/main/java/org/fogbowcloud/manager/core/models/orders/instances/ComputeOrderInstance.java
+++ b/src/main/java/org/fogbowcloud/manager/core/models/orders/instances/ComputeOrderInstance.java
@@ -21,7 +21,8 @@ public class ComputeOrderInstance extends OrderInstance {
     private String sshUserName;
     private String sshExtraPorts;
 
-    public ComputeOrderInstance(String id, String hostName, int vCPU, int memory, InstanceState state, String localIpAddress, String sshPublicAddress, String sshUserName, String sshExtraPorts) {
+    public ComputeOrderInstance(String id, String hostName, int vCPU, int memory, InstanceState state, String localIpAddress,
+                                String sshPublicAddress, String sshUserName, String sshExtraPorts) {
         super(id, state);
         this.hostName = hostName;
         this.vCPU = vCPU;
@@ -30,11 +31,6 @@ public class ComputeOrderInstance extends OrderInstance {
         this.sshPublicAddress = sshPublicAddress;
         this.sshUserName = sshUserName;
         this.sshExtraPorts = sshExtraPorts;
-    }
-
-    // TODO: This method was created to make getInstance() more easy to implement
-    public ComputeOrderInstance(String id, InstanceState state) {
-        super(id, state);
     }
 
     public ComputeOrderInstance(String id) {

--- a/src/main/java/org/fogbowcloud/manager/core/plugins/compute/openstack/OpenStackNovaV2ComputePlugin.java
+++ b/src/main/java/org/fogbowcloud/manager/core/plugins/compute/openstack/OpenStackNovaV2ComputePlugin.java
@@ -399,9 +399,20 @@ public class OpenStackNovaV2ComputePlugin implements ComputePlugin {
             JSONObject serverJson = rootServer.getJSONObject(SERVER_JSON_FIELD);
 
             String id = serverJson.getString(ID_JSON_FIELD);
+            String hostName = serverJson.getString(NAME_JSON_FIELD);
+            int vCPU = serverJson.getJSONObject(FLAVOR_JSON_OBJECT).getInt(VCPU_JSON_FIELD);
+            int memory = serverJson.getJSONObject(FLAVOR_JSON_OBJECT).getInt(MEMORY_JSON_FIELD);
             InstanceState state = getInstanceState(serverJson.getString(STATUS_JSON_FIELD));
 
-            ComputeOrderInstance computeOrderInstance = new ComputeOrderInstance(id, state);
+            // TODO: Why should I pass all this attributes for computeOrderInstance if they are
+            // all related to tunneling? We don't have it on the cloud provider JSON response.
+            String localIpAddress = "";
+            String sshPublicAddress = "";
+            String sshUserName = "";
+            String sshExtraPorts = "";
+
+            ComputeOrderInstance computeOrderInstance = new ComputeOrderInstance(id, hostName, vCPU, memory,
+                    state, localIpAddress, sshPublicAddress, sshUserName, sshExtraPorts);
 
             return computeOrderInstance;
         } catch (JSONException e) {

--- a/src/test/java/org/fogbowcloud/manager/core/plugins/compute/openstack/TestOpenStackComputePlugin.java
+++ b/src/test/java/org/fogbowcloud/manager/core/plugins/compute/openstack/TestOpenStackComputePlugin.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.*;
 public class TestOpenStackComputePlugin {
 
     protected static final String FAKE_USER_DATA_FILE = "fake-extra-user-data";
-    protected static final String FAKE_EXTRA_USER_DATA_FILE_TYPE = "fake-file-type";
     protected static final String FAKE_FLAVOR_ID = "fake-flavor-id";
     protected static final String FAKE_NET_ID = "fake-net-id";
     protected static final String FAKE_KEYNAME = "fake-keyname";
@@ -33,9 +32,12 @@ public class TestOpenStackComputePlugin {
     protected static final String FAKE_IMAGE_ID = "fake-image-id";
     protected static final String FAKE_INSTANCE_ID = "fake-instance-id";
     protected static final String FAKE_POST_RETURN = "{\"server\": {\"id\": \"fake-instance-id\"}}";
-    protected static final String FAKE_GET_RETURN_ACTIVE_INSTANCE = "{\"server\": {\"id\": \"fake-instance-id\", \"status\": \"active\"}}";
-    protected static final String FAKE_GET_RETURN_FAILED_INSTANCE = "{\"server\": {\"id\": \"fake-instance-id\", \"status\": \"error\"}}";
-    protected static final String FAKE_GET_RETURN_INACTIVE_INSTANCE = "{\"server\": {\"id\": \"fake-instance-id\", \"status\": \"build\"}}";
+    protected static final String FAKE_GET_RETURN_ACTIVE_INSTANCE = "{\"server\": {\"id\": \"fake-instance-id\", " +
+            "\"status\": \"active\", \"name\": \"host\", \"flavor\": {\"vcpus\": 1, \"ram\": 3}}}";
+    protected static final String FAKE_GET_RETURN_FAILED_INSTANCE = "{\"server\": {\"id\": \"fake-instance-id\", " +
+            "\"status\": \"error\", \"name\": \"host\", \"flavor\": {\"vcpus\": 1, \"ram\": 3}}}";
+    protected static final String FAKE_GET_RETURN_INACTIVE_INSTANCE = "{\"server\": {\"id\": \"fake-instance-id\", " +
+            "\"status\": \"build\", \"name\": \"host\", \"flavor\": {\"vcpus\": 1, \"ram\": 3}}}";
     protected static final String INVALID_FAKE_POST_RETURN = "invalid";
     private static final String COMPUTE_NOVAV2_URL_KEY = "compute_novav2_url";
     private static final String COMPUTE_NOVAV2_NETWORK_KEY = "compute_novav2_network_id";


### PR DESCRIPTION
Please, read this comment: [TODO](https://github.com/fogbow/fogbow-manager-core/blob/openstack-compute-plugin/src/main/java/org/fogbowcloud/manager/core/plugins/compute/openstack/OpenStackNovaV2ComputePlugin.java#L407).

I'm creating the `ComputeOrderInstance` with all its attributes, however I think it has a bunch of attributes witch are not related to the `ComputeOrderInstance`, since we don't have it on the cloud provider instance response.

**Another point to discuss**: Now the `localIpAddress` is just a `String`, however in the old code it  iterates in a list of addresses (see [old method](https://github.com/fogbow/fogbow-manager/blob/develop/src/main/java/org/fogbowcloud/manager/core/plugins/compute/openstack/OpenStackNovaV2ComputePlugin.java#L445)), so what address should I get from the JSON?:
```javascript
"addresses": {
            "private": [
                {
                    "OS-EXT-IPS-MAC:mac_addr": "aa:bb:cc:dd:ee:ff",
                    "OS-EXT-IPS:type": "fixed",
                    "addr": "192.168.0.3",
                    "version": 4
                }
            ]
        },
```