### PR TITLE
Fix token validation

### DIFF
--- a/src/main/java/org/fogbowcloud/manager/core/plugins/behavior/federationidentity/ldap/LdapIdentityPlugin.java
+++ b/src/main/java/org/fogbowcloud/manager/core/plugins/behavior/federationidentity/ldap/LdapIdentityPlugin.java
@@ -211,7 +211,7 @@ public class LdapIdentityPlugin implements FederationIdentityPlugin {
             Date expirationDate = new Date(root.getLong(ATT_EXPIRATION_DATE));
             Date currentDate = new Date(System.currentTimeMillis());
 
-            if (expirationDate.after(currentDate)) {
+            if (expirationDate.before(currentDate)) {
                 throw new ExpiredTokenException("Expiration date: " + expirationDate);
             }
 


### PR DESCRIPTION
If the **token-expiration-date** is after **current-date** so this one is valid, otherwise, don't. Then, I think using `before` is the correct way to check it.

OBS: I'm using that to validate the token in fogbow-cli, therefore without this fix token is always invalid. :+1: 